### PR TITLE
fix timestamp creation for scoped pkgs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,6 +42,27 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "tap ztest.js",
+      "program": "${workspaceRoot}/test/mock/ztest/bin/ztest.js",
+      "stopOnEntry": true,
+      "args": [
+        "--help"
+      ],
+      "cwd": "${workspaceRoot}",
+      "preLaunchTask": null,
+      "runtimeExecutable": null,
+      "runtimeArgs": [
+        "--nolazy"
+      ],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "console": "internalConsole",
+      "sourceMaps": false
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "tap errors.js",
       "program": "${workspaceRoot}/test/tap/errors.js",
       "stopOnEntry": true,

--- a/lib/cli-application.js
+++ b/lib/cli-application.js
@@ -817,7 +817,8 @@ class CliApplication {
     const context = this.context
     const log = context.log
 
-    const fpath = path.join(timestampsPath, context.package.name +
+    const fpath = path.join(timestampsPath,
+      context.package.name.replace(path.sep, '-') +
       timestampSuffix)
     try {
       const stats = await fs.statPromise(fpath)
@@ -908,7 +909,8 @@ class CliApplication {
 
     await makeDir(timestampsPath)
 
-    const fpath = path.join(timestampsPath, context.package.name +
+    const fpath = path.join(timestampsPath,
+      context.package.name.replace(path.sep, '-') +
       timestampSuffix)
     await del(fpath, { force: true })
 

--- a/test/mock/ztest/main.js
+++ b/test/mock/ztest/main.js
@@ -76,6 +76,10 @@ class Ztest extends CliApplication {
     // the shortcut of using `__dirname` of the main file.
     Self.rootPath = __dirname
 
+    // Run the update check
+    Self.checkUpdatesIntervalSeconds = 5
+    process.stdout.isTTY = true
+
     // ------------------------------------------------------------------------
     // Initialise the tree of known commands.
     // Paths should be relative to the package root.

--- a/test/mock/ztest/package.json
+++ b/test/mock/ztest/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "test",
-  "version": "3.4.5",
+  "name": "@xpack/xpm-liquid",
+  "version": "0.1.2",
   "description": "Mock ZTest",
   "author": {
     "name": "Liviu Ionescu",


### PR DESCRIPTION
Timestamp creation fails on macOS and Linux for scoped pkgs which contain a `/` as part of the package name

Replace `path.sep` with `-`